### PR TITLE
Set texture filtering to linear-mipmap by default

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -18,3 +18,7 @@ config/icon="res://icon.svg"
 [dotnet]
 
 project/assembly_name="DungeonCrawlerJam2023"
+
+[rendering]
+
+textures/canvas_textures/default_texture_filter=3


### PR DESCRIPTION
This is to avoid blurry textures when rendering pixelart. Can be changed on a case-by-case basis but this default is saner.